### PR TITLE
Post-process generated site to use relative URIs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,12 @@ skip in publish := true
 lazy val plugin = project
   .settings(
     sbtPlugin := true,
-    moduleName := "sbt-docusaurus"
+    moduleName := "sbt-docusaurus",
+    libraryDependencies ++= List(
+      "org.jsoup" % "jsoup" % "1.11.3",
+      "org.scalacheck" %% "scalacheck" % "1.13.5" % Test,
+      "org.scalameta" %% "testkit" % "4.0.0-M11" % Test
+    )
   )
 
 lazy val docs = project

--- a/plugin/src/main/scala/sbtdocusaurus/internal/Relativize.scala
+++ b/plugin/src/main/scala/sbtdocusaurus/internal/Relativize.scala
@@ -1,0 +1,77 @@
+package sbtdocusaurus.internal
+
+import java.net.URI
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import scala.collection.JavaConverters._
+
+object Relativize {
+
+  def htmlSite(site: Path): Unit = {
+    Files.walkFileTree(
+      site,
+      new SimpleFileVisitor[Path] {
+        override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+          if (file.getFileName.toString.endsWith(".html")) {
+            processHtmlFile(site, file)
+          }
+          super.visitFile(file, attrs)
+        }
+      }
+    )
+  }
+
+  // actual host name doesn't matter
+  private val baseUri = URI.create("http://example.com/")
+
+  def processHtmlFile(site: Path, file: Path): Unit = {
+    val originRelativeUri = relativeUri(site.relativize(file))
+    val originUri = baseUri.resolve(originRelativeUri)
+    val originPath = Paths.get(originUri.getPath).getParent
+    def relativizeAttribute(a: Element, attribute: String): Unit = {
+      val absoluteHref = URI.create(a.attr(s"abs:$attribute"))
+      if (absoluteHref.getHost == baseUri.getHost) {
+        val hrefPath = Paths.get(absoluteHref.getPath)
+        val relativeHref = {
+          val relativePath = originPath.relativize(hrefPath)
+          val absolutePath = file.getParent.resolve(relativePath)
+          val isDirectory = Files.isDirectory(absolutePath)
+          if (isDirectory) relativePath.resolve("index.html")
+          else relativePath
+        }
+        val fragment =
+          if (absoluteHref.getFragment == null) ""
+          else "#" + absoluteHref.getFragment
+        val newHref = relativeUri(relativeHref).toString + fragment
+        a.attr(attribute, newHref)
+      }
+    }
+    val doc = Jsoup.parse(file.toFile, StandardCharsets.UTF_8.name(), originUri.toString)
+    def relativizeElement(element: String, attribute: String): Unit =
+      doc.select(element).forEach { element =>
+        relativizeAttribute(element, attribute)
+      }
+    relativizeElement("a", "href")
+    relativizeElement("link", "href")
+    relativizeElement("img", "src")
+    val renderedHtml = doc.outerHtml()
+    Files.write(file, renderedHtml.getBytes(StandardCharsets.UTF_8))
+  }
+
+  private def relativeUri(relativePath: Path): URI = {
+    require(!relativePath.isAbsolute, relativePath)
+    val names = relativePath.iterator().asScala
+    val uris = names.map { name =>
+      new URI(null, null, name.toString, null)
+    }
+    URI.create(uris.mkString("", "/", ""))
+  }
+}

--- a/plugin/src/test/scala/tests/RelativizeSuite.scala
+++ b/plugin/src/test/scala/tests/RelativizeSuite.scala
@@ -1,0 +1,127 @@
+package tests
+
+import java.nio.file.Paths
+import org.scalatest.FunSuite
+import sbtdocusaurus.internal.Relativize
+import scala.meta.internal.io.PathIO
+import scala.meta.testkit.DiffAssertions
+import scala.meta.testkit.StringFS
+
+class RelativizeSuite extends FunSuite with DiffAssertions {
+
+  def check(name: String, original: String, expected: String): Unit = {
+    test(name) {
+      val root = StringFS.fromString(original)
+      Relativize.htmlSite(root.toNIO)
+      root.toRelative(PathIO.workingDirectory).toURI(true)
+      val isTrivial = Set(
+        "<html>",
+        "<body>",
+        "<head>",
+        "</head>",
+        "<head></head>",
+        "<body>",
+        "</body>",
+        "<body></body>",
+        "</html>",
+      )
+      val obtained = StringFS
+        .asString(root)
+        .lines
+        .map(_.trim)
+        .filterNot(isTrivial)
+        .mkString("\n")
+      assertNoDiff(obtained, expected)
+    }
+  }
+
+  check(
+    "a:href is processed",
+    """
+      |/index.html
+      |<a href="/docs/about.html"></a>
+      |""".stripMargin,
+    """
+      |/index.html
+      |<a href="docs/about.html"></a>
+      |""".stripMargin,
+  )
+
+  check(
+    "img:src is processed",
+    """
+      |/index.html
+      |<img src="/docs/about.html">
+      |""".stripMargin,
+    """
+      |/index.html
+      |<img src="docs/about.html">
+      |""".stripMargin,
+  )
+
+  check(
+    "link:href is processed",
+    """
+      |/index.html
+      |<link href="/docs/about.html">
+      |""".stripMargin,
+    """
+      |/index.html
+      |<link href="docs/about.html">
+      |""".stripMargin,
+  )
+
+  check(
+    "cross-page",
+    """
+      |/docs/about.html
+      |<a href="/index.html"></a>
+      |
+      |/index.html
+      |<a href="/docs/about.html"></a>
+      |""".stripMargin,
+    """
+      |/docs/about.html
+      |<a href="../index.html"></a>
+      |/index.html
+      |<a href="docs/about.html"></a>
+      |""".stripMargin,
+  )
+
+  check(
+    "fragment is preserved",
+    """
+      |/index.html
+      |<a href="#header"></a>
+      |<a href="/docs/about.html#header"></a>
+      |""".stripMargin,
+    """
+      |/index.html
+      |<a href="index.html#header"></a>
+      |<a href="docs/about.html#header"></a>
+      |""".stripMargin,
+  )
+
+  check(
+    "directory/ is expanded to directory/index.html",
+    """
+      |/docs/about.html
+      |<a href="/"></a>
+      |<a href="/docs"></a>
+      |<a href="/docs/"></a>
+      |<a href="/users/"></a>
+      |/users/index.html
+      |Users
+      |""".stripMargin,
+    """
+      |/docs/about.html
+      |<a href="../index.html"></a>
+      |<a href="index.html"></a>
+      |<a href="index.html"></a>
+      |<a href="../users/index.html"></a>
+      |/users/index.html
+      |Users
+      |""".stripMargin,
+  )
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,5 @@ addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.1")
 addSbtPlugin(
   "io.get-coursier" % "sbt-coursier" % coursier.util.Properties.version
 )
+
+libraryDependencies += "org.jsoup" % "jsoup" % "1.11.3"


### PR DESCRIPTION
The goal of this commit is to make it possible to browse the generated
docusaurus site without a file server. Just open index.html and it
works. One benefit of this change is that it becomes possible to host
the generated site on Maven Central and browse old sites on static.javadoc.io.