### PR TITLE
Make syntax highlighting work on post-processed site

### DIFF
--- a/plugin/src/test/scala/tests/RelativizeSuite.scala
+++ b/plugin/src/test/scala/tests/RelativizeSuite.scala
@@ -103,6 +103,18 @@ class RelativizeSuite extends FunSuite with DiffAssertions {
   )
 
   check(
+    "// is forced to https",
+    """
+      |/index.html
+      |<a href="//cdnjs.cloudflare.com"></a>
+      |""".stripMargin,
+    """
+      |/index.html
+      |<a href="https://cdnjs.cloudflare.com"></a>
+      |""".stripMargin,
+  )
+
+  check(
     "directory/ is expanded to directory/index.html",
     """
       |/docs/about.html


### PR DESCRIPTION
Previously, we kepts `//cdn.cloudflare.com` URLs unchanged causing 404s
while browsing the html files without a file server because those URLs
would fall back to `file://cdn.cloudflare.com`.